### PR TITLE
[Bugfix] Weekly Reset tracking

### DIFF
--- a/WowEfficiency.toc
+++ b/WowEfficiency.toc
@@ -6,7 +6,7 @@
 ## Version: 1.0.0
 ## RequiredDeps:
 # Only after we upload to curseforge
-## X-Curse-Project-ID: 999999
+## X-Curse-Project-ID: 1268061
 ## SavedVariables: WowEfficiencyDB
 # Declare optional dependency
 ## OptionalDeps: Ace3 


### PR DESCRIPTION
## Overview

Weekly reset wasn't working correctly as it was tracked globally instead of per character.

Track reset per character now.