### PR TITLE
[Feature] Track more features and fix enchanting trainer quest bug

### DIFF
--- a/Data/Quests/Midnight/Professions/Enchanting.lua
+++ b/Data/Quests/Midnight/Professions/Enchanting.lua
@@ -8,7 +8,7 @@ WowEfficiency.ProfessionQuests.Midnight = WowEfficiency.ProfessionQuests.Midnigh
 -- Populate Enchanting quest data
 WowEfficiency.ProfessionQuests.Midnight.Enchanting = {
     Gathering = { 95048, 95049, 95050, 95051, 95052, 95053 },
-    Trainer = { 93698, 93699 },
+    Trainer = { 93697, 93698, 93699 },
     Treasure = { 93532, 93533 },
     Treatise = { 95129 },
     Uniques = { 89100, 89101, 89102, 89103, 89104, 89105, 89106, 89107, 92186, 92374 },

--- a/Modules/Bank.lua
+++ b/Modules/Bank.lua
@@ -1,0 +1,41 @@
+-- Get the addon name passed by WoW when loading the file
+local addonName = select(1, ...)
+
+-- Get the main addon object
+---@type WoWEfficiency_Addon
+local WoWEfficiency = LibStub('AceAddon-3.0'):GetAddon(addonName)
+
+-- Fetch shared functionality
+---@type WoWEfficiency_Debug
+local Debug = WoWEfficiency:GetModule('Debug')
+---@type WoWEfficiency_DB
+local db = WoWEfficiency:GetModule('DB')
+
+-- Define the module
+---@class WoWEfficiency_Bank: AceModule, AceEvent-3.0
+---@field UpdateWarbankGold fun(self: WoWEfficiency_Bank)
+local Module = WoWEfficiency:NewModule('Bank', "AceEvent-3.0")
+
+-- Upvalue global functions
+local C_Bank_FetchDepositedMoney = C_Bank.FetchDepositedMoney
+local Enum_BankType_Account = Enum.BankType.Account
+
+function Module:OnEnable()
+    Debug:DebugPrint("Bank Module Enabled.")
+
+    -- TODO: Verify these event names in-game. They may differ from the expected names.
+    self:RegisterEvent('BANKFRAME_OPENED', "UpdateWarbankGold")
+    self:RegisterEvent('BANKFRAME_CLOSED', "UpdateWarbankGold")
+end
+
+function Module:UpdateWarbankGold()
+    local gold = C_Bank_FetchDepositedMoney(Enum_BankType_Account)
+    if gold == nil then
+        Debug:DebugPrint("Bank: FetchDepositedMoney returned nil, skipping update")
+        return
+    end
+
+    db:GetDB().global.warbankGold = gold
+
+    Debug:DebugPrint("Warbank gold updated: " .. gold)
+end

--- a/Modules/Bank.lua
+++ b/Modules/Bank.lua
@@ -23,7 +23,6 @@ local Enum_BankType_Account = Enum.BankType.Account
 function Module:OnEnable()
     Debug:DebugPrint("Bank Module Enabled.")
 
-    -- TODO: Verify these event names in-game. They may differ from the expected names.
     self:RegisterEvent('BANKFRAME_OPENED', "UpdateWarbankGold")
     self:RegisterEvent('BANKFRAME_CLOSED', "UpdateWarbankGold")
 end

--- a/Modules/Currencies.lua
+++ b/Modules/Currencies.lua
@@ -1,0 +1,87 @@
+-- Get the addon name passed by WoW when loading the file
+local addonName = select(1, ...)
+
+-- Get the main addon object
+---@type WoWEfficiency_Addon
+local WoWEfficiency = LibStub('AceAddon-3.0'):GetAddon(addonName)
+
+-- Fetch shared functionality
+---@type WoWEfficiency_Debug
+local Debug = WoWEfficiency:GetModule('Debug')
+---@type WoWEfficiency_DB
+local db = WoWEfficiency:GetModule('DB')
+
+-- Define the module
+---@class WoWEfficiency_Currencies: AceModule, AceEvent-3.0
+---@field UpdateCurrencies fun(self: WoWEfficiency_Currencies)
+local Module = WoWEfficiency:NewModule('Currencies', "AceEvent-3.0")
+
+-- Upvalue global functions
+local C_CurrencyInfo_GetCurrencyInfo = C_CurrencyInfo.GetCurrencyInfo
+local C_CurrencyInfo_FetchCurrencyDataFromAccountCharacters = C_CurrencyInfo.FetchCurrencyDataFromAccountCharacters
+
+-- Tracked currency IDs. Add new currencies here as needed.
+-- Format: [currencyID] = true
+Module.TrackedCurrencies = {
+    [3316] = true, -- Voidlight Marl
+}
+
+function Module:OnEnable()
+    Debug:DebugPrint("Currencies Module Enabled.")
+
+    self:RegisterEvent('PLAYER_ENTERING_WORLD', "UpdateCurrencies")
+    self:RegisterEvent('CURRENCY_DISPLAY_UPDATE', "UpdateCurrencies")
+    self:RegisterEvent('ACCOUNT_CHARACTER_CURRENCY_DATA_RECEIVED', "UpdateAccountCurrencies")
+end
+
+-- Update currencies for the current character
+function Module:UpdateCurrencies()
+    if not db:IsCharDBReady() then return end
+
+    local currenciesDB = db:GetCharDBKey("currencies")
+
+    for currencyID in pairs(Module.TrackedCurrencies) do
+        local info = C_CurrencyInfo_GetCurrencyInfo(currencyID)
+        if info then
+            currenciesDB[currencyID] = {
+                currencyID = currencyID,
+                amount = info.quantity,
+                maxQuantity = info.maxQuantity,
+            }
+        end
+    end
+
+    db:UpdateCharDBKey("currencies", currenciesDB)
+
+    Debug:DebugPrint("Currencies updated")
+end
+
+-- Update account currencies for all characters
+function Module:UpdateAccountCurrencies()
+    local currenciesDB = db:GetDB().global.currencies
+
+    for currencyID in pairs(Module.TrackedCurrencies) do
+        -- Fetch account currencies
+        local accountCurrencies = C_CurrencyInfo_FetchCurrencyDataFromAccountCharacters(currencyID)
+        if accountCurrencies then
+            -- Ensure specific currency sub-table exists
+            if not currenciesDB[currencyID] then
+                currenciesDB[currencyID] = {}
+            end
+
+            -- For each character
+            for _, currencyData in pairs(accountCurrencies) do
+                currenciesDB[currencyID][currencyData.fullCharacterName] = {
+                    currencyID = currencyID,
+                    amount = currencyData.quantity,
+                    maxQuantity = 0, -- Not available for account currencies
+                }
+            end
+        end
+    end
+
+    db:GetDB().global.currencies = currenciesDB
+    db:TrackGlobalLastUpdated("currencies")
+
+    Debug:DebugPrint("Account currencies updated")
+end

--- a/Modules/DB.lua
+++ b/Modules/DB.lua
@@ -104,6 +104,7 @@ function Module:TrackGlobalLastUpdated(category)
     self.db.global.lastUpdated[category] = GetServerTime()
     self.db.global.lastUpdatedISO[category] = date("!%Y-%m-%dT%H:%M:%SZ")
 end
+
 function Module:HandleWeeklyReset()
     local currentTime = GetServerTime()
     local nextWeeklyReset = GetServerTime() + C_DateAndTime.GetSecondsUntilWeeklyReset()

--- a/Modules/DB.lua
+++ b/Modules/DB.lua
@@ -28,13 +28,19 @@ local dbDefaults = {
         lastUpdatedISO = {}, -- Stores { [category] = ISO 8601 timestamp } for last updated time for each category
         logs = {}, -- Stores { [timestamp] = msg } for logs.
         nextWeeklyReset = 0, -- Stores the server time for this character's next weekly reset processing
+        currencies = {}, -- Stores { [currencyID] = { currencyID, amount, maxQuantity } } for tracked currencies.
         -- Add other character-specific settings here later
     },
     profile = { -- Settings shared across characters using this profile
         debugMode = false,
     },
-    global = { 
+    global = {
         weeklyResetTime = 0, -- Updated once per week.
+        warbankGold = 0, -- Account bank (warbank) gold in copper, updated when bank is opened/closed.
+        region = "", -- Account region (e.g. "us", "eu"), set on login.
+        currencies = {}, -- Stores { [currencyID] = { [characterName] = { currencyID, amount, maxQuantity } } } for tracked currencies.
+        lastUpdated = {}, -- Stores { [category] = timestamp } for last updated time for each category
+        lastUpdatedISO = {}, -- Stores { [category] = ISO 8601 timestamp } for last updated time for each category
     }
 }
 
@@ -42,6 +48,8 @@ function Module:OnInitialize()
     -- Initialize database
     self.db = LibStub("AceDB-3.0"):New("WowEfficiencyDB", dbDefaults, true) -- 'true' for character-specific DB
 
+    -- Region is constant for the session; store globally for the website to read.
+    self.db.global.region = string.lower(GetCurrentRegionName())
     -- Handle weekly reset
     self:HandleWeeklyReset()
 
@@ -92,6 +100,10 @@ function Module:TrackLastUpdated(category)
     self.db.char.lastUpdatedISO[category] = date("!%Y-%m-%dT%H:%M:%SZ")
 end
 
+function Module:TrackGlobalLastUpdated(category)
+    self.db.global.lastUpdated[category] = GetServerTime()
+    self.db.global.lastUpdatedISO[category] = date("!%Y-%m-%dT%H:%M:%SZ")
+end
 function Module:HandleWeeklyReset()
     local currentTime = GetServerTime()
     local nextWeeklyReset = GetServerTime() + C_DateAndTime.GetSecondsUntilWeeklyReset()

--- a/Modules/Professions.lua
+++ b/Modules/Professions.lua
@@ -104,6 +104,18 @@ local ExtractExpansionData = function(variantConstants, existingData)
         end
     end
 
+    -- Moxie currency info
+    if variantConstants.moxieCurrencyID then
+        local moxieInfo = C_CurrencyInfo_GetCurrencyInfo(variantConstants.moxieCurrencyID)
+        if moxieInfo and moxieInfo.quantity then
+            expansionStruct.moxie = {
+                currencyID = variantConstants.moxieCurrencyID,
+                amount = moxieInfo.quantity,
+                maxQuantity = moxieInfo.maxQuantity,
+            }
+        end
+    end
+
     -- Knowledge level sum
     local knowledgeLevelSum = 0
     local knowledgeMaxLevelSum = 0
@@ -212,66 +224,66 @@ Module.Constants = {
         name = "Alchemy",
         skillLineID = 171,
         TWW = { minLevel = 70, skillLineVariantID = 2871, catchUpCurrencyID = 3057 },
-        Midnight = { minLevel = 80, skillLineVariantID = 2906, catchUpCurrencyID = 3189 },
+        Midnight = { minLevel = 80, skillLineVariantID = 2906, catchUpCurrencyID = 3189, moxieCurrencyID = 3256 },
     },
     [164] = {
         name = "Blacksmithing",
         skillLineID = 164,
         TWW = { minLevel = 70, skillLineVariantID = 2872, catchUpCurrencyID = 3058 },
-        Midnight = { minLevel = 80, skillLineVariantID = 2907, catchUpCurrencyID = 3199 },
+        Midnight = { minLevel = 80, skillLineVariantID = 2907, catchUpCurrencyID = 3199, moxieCurrencyID = 3257 },
     },
     [333] = {
         name = "Enchanting",
         skillLineID = 333,
         TWW = { minLevel = 70, skillLineVariantID = 2874, catchUpCurrencyID = 3059 },
-        Midnight = { minLevel = 80, skillLineVariantID = 2909, catchUpCurrencyID = 3198 },
+        Midnight = { minLevel = 80, skillLineVariantID = 2909, catchUpCurrencyID = 3198, moxieCurrencyID = 3258 },
     },
     [202] = {
         name = "Engineering",
         skillLineID = 202,
         TWW = { minLevel = 70, skillLineVariantID = 2875, catchUpCurrencyID = 3060 },
-        Midnight = { minLevel = 80, skillLineVariantID = 2910, catchUpCurrencyID = 3197 },
+        Midnight = { minLevel = 80, skillLineVariantID = 2910, catchUpCurrencyID = 3197, moxieCurrencyID = 3259 },
     },
     [182] = {
         name = "Herbalism",
         skillLineID = 182,
         TWW = { minLevel = 70, skillLineVariantID = 2877, catchUpCurrencyID = 3061 },
-        Midnight = { minLevel = 80, skillLineVariantID = 2912, catchUpCurrencyID = 3196 },
+        Midnight = { minLevel = 80, skillLineVariantID = 2912, catchUpCurrencyID = 3196, moxieCurrencyID = 3260 },
     },
     [773] = {
         name = "Inscription",
         skillLineID = 773,
         TWW = { minLevel = 70, skillLineVariantID = 2878, catchUpCurrencyID = 3062 },
-        Midnight = { minLevel = 80, skillLineVariantID = 2913, catchUpCurrencyID = 3195 },
+        Midnight = { minLevel = 80, skillLineVariantID = 2913, catchUpCurrencyID = 3195, moxieCurrencyID = 3261 },
     },
     [755] = {
         name = "Jewelcrafting",
         skillLineID = 755,
         TWW = { minLevel = 70, skillLineVariantID = 2879, catchUpCurrencyID = 3063 },
-        Midnight = { minLevel = 80, skillLineVariantID = 2914, catchUpCurrencyID = 3194 },
+        Midnight = { minLevel = 80, skillLineVariantID = 2914, catchUpCurrencyID = 3194, moxieCurrencyID = 3262 },
     },
     [165] = {
         name = "Leatherworking",
         skillLineID = 165,
         TWW = { minLevel = 70, skillLineVariantID = 2880, catchUpCurrencyID = 3064 },
-        Midnight = { minLevel = 80, skillLineVariantID = 2915, catchUpCurrencyID = 3193 },
+        Midnight = { minLevel = 80, skillLineVariantID = 2915, catchUpCurrencyID = 3193, moxieCurrencyID = 3263 },
     },
     [186] = {
         name = "Mining",
         skillLineID = 186,
         TWW = { minLevel = 70, skillLineVariantID = 2881, catchUpCurrencyID = 3065 },
-        Midnight = { minLevel = 80, skillLineVariantID = 2916, catchUpCurrencyID = 3192 },
+        Midnight = { minLevel = 80, skillLineVariantID = 2916, catchUpCurrencyID = 3192, moxieCurrencyID = 3264 },
     },
     [393] = {
         name = "Skinning",
         skillLineID = 393,
         TWW = { minLevel = 70, skillLineVariantID = 2882, catchUpCurrencyID = 3066 },
-        Midnight = { minLevel = 80, skillLineVariantID = 2917, catchUpCurrencyID = 3191 },
+        Midnight = { minLevel = 80, skillLineVariantID = 2917, catchUpCurrencyID = 3191, moxieCurrencyID = 3265 },
     },
     [197] = {
         name = "Tailoring",
         skillLineID = 197,
         TWW = { minLevel = 70, skillLineVariantID = 2883, catchUpCurrencyID = 3067 },
-        Midnight = { minLevel = 80, skillLineVariantID = 2918, catchUpCurrencyID = 3190 },
+        Midnight = { minLevel = 80, skillLineVariantID = 2918, catchUpCurrencyID = 3190, moxieCurrencyID = 3266 },
     },
 }

--- a/WowEfficiency.toc
+++ b/WowEfficiency.toc
@@ -62,5 +62,9 @@ Modules\Quests.lua
 Modules\Professions.lua
 Modules\Professions\Cooldowns.lua
 Modules\Professions\Concentration.lua
+# Bank
+Modules\Bank.lua
+# Currencies
+Modules\Currencies.lua
 # Core
 Core.lua


### PR DESCRIPTION
## Overview

- Add tracking for warbank gold, allowing a correct summary of "total gold" for an account
- Add tracking for moxie for each profession, will allow highlighting when >600 for reagent bag
- Add tracking for voidlight marl across all characters
- Add tracking for which region the account is for, allows support for multi-region in wowefficiency website
- Fix a bug with missing enchanting trainer quest id